### PR TITLE
Add config for sending emails and force verification on sign-up

### DIFF
--- a/mlite_rails_app/Gemfile
+++ b/mlite_rails_app/Gemfile
@@ -63,3 +63,4 @@ gem 'aws-sdk-sqs'
 gem 'whenever', require: false
 gem 'numo-narray'
 # gem 'numo-linalg'
+gem 'mail'

--- a/mlite_rails_app/Gemfile.lock
+++ b/mlite_rails_app/Gemfile.lock
@@ -344,6 +344,7 @@ DEPENDENCIES
   dotenv-rails
   importmap-rails
   jbuilder
+  mail
   numo-narray
   pg (~> 1.1)
   puma (>= 5.0)

--- a/mlite_rails_app/app/models/user.rb
+++ b/mlite_rails_app/app/models/user.rb
@@ -2,7 +2,8 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable,
+         :confirmable
 
   has_many :datasets, dependent: :destroy
   has_many :models, through: :datasets

--- a/mlite_rails_app/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/mlite_rails_app/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,5 @@
 <p>Welcome <%= @email %>!</p>
 
-<p>You can confirm your account email through the link below:</p>
+<p>You can confirm your MLite account email through the link below:</p>
 
 <p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/mlite_rails_app/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/mlite_rails_app/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,6 +1,6 @@
 <p>Hello <%= @resource.email %>!</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p>Someone has requested a link to change your MLite password. You can do this through the link below.</p>
 
 <p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
 

--- a/mlite_rails_app/config/environments/development.rb
+++ b/mlite_rails_app/config/environments/development.rb
@@ -33,8 +33,18 @@ Rails.application.configure do
 
   config.active_storage.service = :local
 
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    user_name: 'apikey', # Fixed SendGrid username
+    password: ENV['SENDGRID_API_KEY'], # Use your API key here
+    address: 'smtp.sendgrid.net',
+    port: '587',
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
+
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   # Disable caching for Action Mailer templates even if Action Controller
   # caching is enabled.

--- a/mlite_rails_app/config/environments/production.rb
+++ b/mlite_rails_app/config/environments/production.rb
@@ -77,6 +77,19 @@ Rails.application.configure do
   # Disable caching for Action Mailer templates even if Action Controller
   # caching is enabled.
   config.action_mailer.perform_caching = false
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    user_name: 'apikey', # Fixed SendGrid username
+    password: ENV['SENDGRID_API_KEY'], # Use your API key here
+    address: 'smtp.sendgrid.net',
+    port: '587',
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
+  config.action_mailer.default_url_options = {
+    host: ENV.fetch("RAILS_APP_HOST", "localhost"),
+    port: ENV["RAILS_APP_PORT"]&.to_i # Omit the port if not set
+  }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/mlite_rails_app/config/initializers/devise.rb
+++ b/mlite_rails_app/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'mohammad.mlite@gmail.com'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/mlite_rails_app/config/locales/devise.en.yml
+++ b/mlite_rails_app/config/locales/devise.en.yml
@@ -20,7 +20,7 @@ en:
       confirmation_instructions:
         subject: "Confirmation instructions"
       reset_password_instructions:
-        subject: "Reset password instructions"
+        subject: "MLite - Reset password instructions"
       unlock_instructions:
         subject: "Unlock instructions"
       email_changed:

--- a/mlite_rails_app/config/locales/devise.en.yml
+++ b/mlite_rails_app/config/locales/devise.en.yml
@@ -18,7 +18,7 @@ en:
       unconfirmed: "You have to confirm your email address before continuing."
     mailer:
       confirmation_instructions:
-        subject: "Confirmation instructions"
+        subject: "MLite - Confirmation instructions"
       reset_password_instructions:
         subject: "MLite - Reset password instructions"
       unlock_instructions:

--- a/mlite_rails_app/db/migrate/20241124230338_add_confirmable_to_users.rb
+++ b/mlite_rails_app/db/migrate/20241124230338_add_confirmable_to_users.rb
@@ -1,0 +1,10 @@
+class AddConfirmableToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+    add_column :users, :unconfirmed_email, :string # Only if using reconfirmable
+
+    add_index :users, :confirmation_token, unique: true
+  end
+end

--- a/mlite_rails_app/db/schema.rb
+++ b/mlite_rails_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_27_154120) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_24_230338) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -46,7 +46,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_27_154120) do
     t.string "name"
     t.text "description"
     t.integer "size"
-    t.json "columns", default: []
+    t.json "columns"
     t.integer "n_rows"
     t.string "dataset_type"
     t.json "metrics"
@@ -91,6 +91,11 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_27_154120) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
changes
- app sends out emails through SendGrid for forget password and reset password (both dev & prod)
- users are required to verify their accounts before signing up through confirmation email. 