### PR TITLE
fixing one hot encode

### DIFF
--- a/flask_app/.ipynb_checkpoints/app2-checkpoint.py
+++ b/flask_app/.ipynb_checkpoints/app2-checkpoint.py
@@ -1,0 +1,58 @@
+import boto3
+from flask import Flask, jsonify, request
+from threading import Thread
+from sqs_handler import poll_sqs
+import requests
+from dotenv import load_dotenv
+import os
+load_dotenv()
+
+
+# Initialize Flask app
+app = Flask(__name__)
+
+# AWS SQS Configuration
+AWS_REGION = 'us-east-1'
+QUEUE_URL = 'https://sqs.us-east-1.amazonaws.com/209479273389/ml_training_requests.fifo'
+
+# Initialize SQS client
+sqs_client = boto3.client('sqs', region_name=AWS_REGION, aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"), aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"))
+
+@app.route('/queue_job', methods=['POST'])
+def queue_job():
+    """
+    API endpoint to add a job to the SQS queue.
+    Expects a JSON payload with job details.
+    """
+    try:
+        # Get job details from the request body
+        job_data = request.json
+        if not job_data:
+            return jsonify({"error": "No job data provided"}), 400
+        
+        # Send job to SQS queue
+        response = sqs_client.send_message(
+            QueueUrl=QUEUE_URL,
+            MessageBody=str(job_data)  # Convert the job data to a string
+        )
+
+        # Return success response
+        return jsonify({
+            "message": "Job added to queue",
+            "job_id": response.get("MessageId")
+        }), 200
+
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+if __name__ == "__main__":
+    # Start SQS polling in a separate thread
+    polling_thread = Thread(target=poll_sqs, daemon=True)
+    polling_thread.start()
+
+    # Start Flask server
+    app.run(debug=True)
+
+
+
+    

--- a/flask_app/.ipynb_checkpoints/sqs_handler-checkpoint.py
+++ b/flask_app/.ipynb_checkpoints/sqs_handler-checkpoint.py
@@ -1,0 +1,121 @@
+from __future__ import absolute_import
+import boto3
+import time
+import json
+import os
+import requests
+from sklearn.linear_model import LogisticRegression, LinearRegression
+import pickle
+
+import sys
+import os
+
+# Add the parent directory to sys.path
+# primarily a python quirk -- may need to eventually create a parent directory runfile
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from src.ML.ML_API import MLAPI
+
+# AWS SQS Configuration
+AWS_REGION = 'us-east-1'
+QUEUE_URL = 'https://sqs.us-east-1.amazonaws.com/209479273389/ml_training_requests.fifo'
+
+def download_file_from_s3(bucket_name, key, download_path):
+    s3_client = boto3.client('s3', region_name=AWS_REGION, aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"), aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"))
+    try:
+        s3_client.download_file(bucket_name, key, download_path)
+
+    except Exception as e:
+        print(f"Error downloading or using the file: {str(e)}")
+
+def upload_file_to_rails(model_id, file_path):
+    RAILS_APP_HOST=os.getenv("RAILS_APP_HOST")
+    RAILS_APP_PORT=os.getenv("RAILS_APP_PORT")
+    auth_token = os.getenv("UPLOAD_AUTH_TOKEN")
+    rails_url = f"{'http://localhost' if RAILS_APP_HOST == 'localhost' or not RAILS_APP_HOST else RAILS_APP_HOST}{f':{RAILS_APP_PORT}' if RAILS_APP_PORT else ''}/models/{model_id}/upload_file?auth_token={auth_token}"
+
+    try:
+        with open(file_path, 'rb') as file:
+            files = {'file': file}
+            response = requests.post(rails_url, files=files)
+
+        if response.status_code == 200:
+            {"message": "File uploaded successfully", "response": response.json()}
+        else:
+            {"error": "Failed to upload file", "details": response.json()}, response.status_code
+
+    except Exception as e:
+        {"error": "Something went wrong", "details": str(e)}, 500
+
+def train_model(model_type, hyperparams, label):
+    api = MLAPI()
+    api.set_local_csv_dataset(dataset='dataset.csv')
+    if model_type == "logistic_regression":
+        # api.one_hot_encode()
+        model = api.logistic_regression(label=label)
+    if model_type == "decision_tree":
+        # api.one_hot_encode()
+        model = api.decision_tree(label=label)
+    if model_type == "linear_regression":
+        # api.one_hot_encode()
+        model = api.linear_regression(label=label)
+    if model_type == "svm":
+        # api.one_hot_encode()
+        model = api.svm(label=label)
+    return model
+
+def poll_sqs():
+    """
+    Continuously polls the SQS queue for messages and processes them one by one.
+    """
+    print("Starting SQS polling...")
+    # Initialize SQS client
+    sqs_client = boto3.client('sqs', region_name=AWS_REGION, aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"), aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"))
+
+    while True:
+        try:
+            # Receive a single message from the SQS queue
+            response = sqs_client.receive_message(
+                QueueUrl=QUEUE_URL,
+                MaxNumberOfMessages=1,  # Poll one message at a time
+                WaitTimeSeconds=10      # Long polling (wait up to 10 seconds if no messages)
+            )
+
+            messages = response.get('Messages', [])
+            if not messages:
+                print("No messages in the queue. Waiting...")
+                continue
+
+            for message in messages:
+                print(f"Received message: {message['Body']}")
+
+                process_message(message['Body'])
+
+                # Delete the message after processing
+                sqs_client.delete_message(
+                    QueueUrl=QUEUE_URL,
+                    ReceiptHandle=message['ReceiptHandle']
+                )
+                print("Message processed and deleted from the queue.")
+
+        except Exception as e:
+            print(f"Error while polling SQS: {str(e)}")
+            time.sleep(5)  # Wait before retrying
+
+
+def process_message(message_body):
+    message = json.loads(message_body)
+    
+    model_id = message['training_params']['model']['id']
+    model_type = message['training_params']['model']['model_type']
+    hyperparams = message['training_params']['model']['hyperparams']
+    label = message['training_params']['model']['labels'][0]
+    dataset_s3_key = message['training_params']['dataset_s3_key']
+
+    print(f"Processing job: {model_id} with dataset: {dataset_s3_key}")
+    download_file_from_s3(os.environ.get('AWS_S3_BUCKET'), dataset_s3_key, 'dataset.csv')
+    model = train_model(model_type, hyperparams, label)
+    # model = LinearRegression() # hardcode model for now
+    with open('model.pkl', 'wb') as file:
+        pickle.dump(model, file)
+    upload_file_to_rails(model_id, 'model.pkl')
+    print(f"Job {model_id} completed.")

--- a/src/ML/.ipynb_checkpoints/ML_API-checkpoint.ipynb
+++ b/src/ML/.ipynb_checkpoints/ML_API-checkpoint.ipynb
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 34,
    "metadata": {
     "id": "EAKwFe1mTfqp"
    },
@@ -60,17 +60,36 @@
     "        except:\n",
     "            return 0\n",
     "\n",
-    "    def one_hot_encode(self, inplace=True, dataset=None, cutoff = 10, columns=None):\n",
+    "    def one_hot_encode(self, inplace=False, cutoff = 10, columns=None, ignore_target=True, target=None):\n",
     "        # TODO: Fix this\n",
     "        \n",
     "        # do a one hot encode of the current dataset and then return \n",
     "        # the new column names alongside the new dataframe\n",
-    "        print(\"TESTING\")\n",
+    "        print(\"encoding categorical data\")\n",
+    "        \n",
     "        try:\n",
     "            print(\"Columns: \")\n",
-    "            print ([self.dataset[col].unique().tolist() for col in self.dataset.columns])\n",
-    "            one_hot_df = pd.get_dummies(self.dataset)\n",
-    "        \n",
+    "            \n",
+    "            if columns != None:\n",
+    "                encode_cols = columns\n",
+    "            else:\n",
+    "                encode_cols = [col for col in self.dataset.columns if self.dataset[col].dtype == 'object']\n",
+    "            try:\n",
+    "                if ignore_target == True and target != None:\n",
+    "                    encode_cols.remove(target)\n",
+    "                else:\n",
+    "                    target = self.dataset.columns.tolist()[-1]\n",
+    "                    del encode_cols[target]\n",
+    "            except:\n",
+    "                print(\"Target variable not in encoding columns.\")\n",
+    "            \n",
+    "            # print ([self.dataset[col].unique().tolist() for col in self.dataset.columns])\n",
+    "            one_hot_df = pd.get_dummies(data=self.dataset, columns=encode_cols)\n",
+    "            if ignore_target == True and target != None:\n",
+    "                pd.concat([one_hot_df, self.dataset[[target]]])\n",
+    "            else:\n",
+    "                pd.concat([one_hot_df, self.dataset.iloc[:,-1:]])\n",
+    "                \n",
     "            new_columns = one_hot_df.columns.difference(self.dataset.columns).tolist()\n",
     "            \n",
     "        # catch when df1 is None\n",
@@ -138,14 +157,16 @@
     "        return r2\n",
     "        \n",
     "    def recommed_model(self, columns, features):\n",
-    "        # should probably mostly rely upon user input to recommend a model\n",
-    "        # if data is linear and wants easy explanation -> linear\n",
-    "        # linear data + categorical data -> logistic regression\n",
-    "        # we can get linearity from R^2 score?\n",
-    "        # high dimensional data + easy explanation or large amount of entries -> decision tree\n",
-    "        # high dimensional data + higher accuracy + fewer entries -> SVM\n",
-    "        # SVM takes longer to train than most trees\n",
-    "        # TODO: add naive bayes algorithm to class\n",
+    "        \"\"\"\n",
+    "        should probably mostly rely upon user input to recommend a model\n",
+    "        if data is linear and wants easy explanation -> linear\n",
+    "        linear data + categorical data -> logistic regression\n",
+    "        we can get linearity from R^2 score?\n",
+    "        high dimensional data + easy explanation or large amount of entries -> decision tree\n",
+    "        high dimensional data + higher accuracy + fewer entries -> SVM\n",
+    "        SVM takes longer to train than most trees\n",
+    "        TODO: add naive bayes algorithm to class\n",
+    "        \"\"\"\n",
     "\n",
     "        X = self.dataset[features].values\n",
     "        y = self.dataset[columns].values.flatten()\n",
@@ -357,7 +378,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -379,14 +400,6 @@
      "traceback": [
       "An exception has occurred, use %tb to see the full traceback.\n",
       "\u001b[0;31mSystemExit\u001b[0m\u001b[0;31m:\u001b[0m 2\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/anaconda3/lib/python3.11/site-packages/IPython/core/interactiveshell.py:3516: UserWarning: To exit: use 'exit', 'quit', or Ctrl-D.\n",
-      "  warn(\"To exit: use 'exit', 'quit', or Ctrl-D.\", stacklevel=1)\n"
      ]
     }
    ],
@@ -436,7 +449,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
@@ -444,7 +457,7 @@
      "output_type": "stream",
      "text": [
       "[NbConvertApp] Converting notebook ML_API.ipynb to script\n",
-      "[NbConvertApp] Writing 15186 bytes to ML_API.py\n"
+      "[NbConvertApp] Writing 16109 bytes to ML_API.py\n"
      ]
     }
    ],

--- a/src/ML/.ipynb_checkpoints/ML_test-checkpoint.ipynb
+++ b/src/ML/.ipynb_checkpoints/ML_test-checkpoint.ipynb
@@ -11,7 +11,7 @@
      "output_type": "stream",
      "text": [
       "[NbConvertApp] Converting notebook ML_API.ipynb to script\n",
-      "[NbConvertApp] Writing 15185 bytes to ML_API.py\n"
+      "[NbConvertApp] Writing 16045 bytes to ML_API.py\n"
      ]
     }
    ],
@@ -71,6 +71,155 @@
     "api = MLAPI()\n",
     "api.set_local_csv_dataset()\n",
     "print(api.dataset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "1a5c7d4e-4e2a-41cf-8084-80809dcc72a3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "encoding categorical data\n",
+      "Columns: \n",
+      "Target variable not in encoding columns.\n",
+      "     sepal length (cm)  sepal width (cm)  petal length (cm)  petal width (cm)  \\\n",
+      "0                  5.1               3.5                1.4               0.2   \n",
+      "1                  4.9               3.0                1.4               0.2   \n",
+      "2                  4.7               3.2                1.3               0.2   \n",
+      "3                  4.6               3.1                1.5               0.2   \n",
+      "4                  5.0               3.6                1.4               0.2   \n",
+      "..                 ...               ...                ...               ...   \n",
+      "145                6.7               3.0                5.2               2.3   \n",
+      "146                6.3               2.5                5.0               1.9   \n",
+      "147                6.5               3.0                5.2               2.0   \n",
+      "148                6.2               3.4                5.4               2.3   \n",
+      "149                5.9               3.0                5.1               1.8   \n",
+      "\n",
+      "     target  \n",
+      "0       0.0  \n",
+      "1       0.0  \n",
+      "2       0.0  \n",
+      "3       0.0  \n",
+      "4       0.0  \n",
+      "..      ...  \n",
+      "145     2.0  \n",
+      "146     2.0  \n",
+      "147     2.0  \n",
+      "148     2.0  \n",
+      "149     2.0  \n",
+      "\n",
+      "[150 rows x 5 columns]\n",
+      "[]\n",
+      "encoding categorical data\n",
+      "Columns: \n",
+      "Target variable not in encoding columns.\n",
+      "     sepal width (cm)  petal length (cm)  petal width (cm)  target  \\\n",
+      "0                 3.5                1.4               0.2     0.0   \n",
+      "1                 3.0                1.4               0.2     0.0   \n",
+      "2                 3.2                1.3               0.2     0.0   \n",
+      "3                 3.1                1.5               0.2     0.0   \n",
+      "4                 3.6                1.4               0.2     0.0   \n",
+      "..                ...                ...               ...     ...   \n",
+      "145               3.0                5.2               2.3     2.0   \n",
+      "146               2.5                5.0               1.9     2.0   \n",
+      "147               3.0                5.2               2.0     2.0   \n",
+      "148               3.4                5.4               2.3     2.0   \n",
+      "149               3.0                5.1               1.8     2.0   \n",
+      "\n",
+      "     sepal length (cm)_4.3  sepal length (cm)_4.4  sepal length (cm)_4.5  \\\n",
+      "0                    False                  False                  False   \n",
+      "1                    False                  False                  False   \n",
+      "2                    False                  False                  False   \n",
+      "3                    False                  False                  False   \n",
+      "4                    False                  False                  False   \n",
+      "..                     ...                    ...                    ...   \n",
+      "145                  False                  False                  False   \n",
+      "146                  False                  False                  False   \n",
+      "147                  False                  False                  False   \n",
+      "148                  False                  False                  False   \n",
+      "149                  False                  False                  False   \n",
+      "\n",
+      "     sepal length (cm)_4.6  sepal length (cm)_4.7  sepal length (cm)_4.8  ...  \\\n",
+      "0                    False                  False                  False  ...   \n",
+      "1                    False                  False                  False  ...   \n",
+      "2                    False                   True                  False  ...   \n",
+      "3                     True                  False                  False  ...   \n",
+      "4                    False                  False                  False  ...   \n",
+      "..                     ...                    ...                    ...  ...   \n",
+      "145                  False                  False                  False  ...   \n",
+      "146                  False                  False                  False  ...   \n",
+      "147                  False                  False                  False  ...   \n",
+      "148                  False                  False                  False  ...   \n",
+      "149                  False                  False                  False  ...   \n",
+      "\n",
+      "     sepal length (cm)_6.8  sepal length (cm)_6.9  sepal length (cm)_7.0  \\\n",
+      "0                    False                  False                  False   \n",
+      "1                    False                  False                  False   \n",
+      "2                    False                  False                  False   \n",
+      "3                    False                  False                  False   \n",
+      "4                    False                  False                  False   \n",
+      "..                     ...                    ...                    ...   \n",
+      "145                  False                  False                  False   \n",
+      "146                  False                  False                  False   \n",
+      "147                  False                  False                  False   \n",
+      "148                  False                  False                  False   \n",
+      "149                  False                  False                  False   \n",
+      "\n",
+      "     sepal length (cm)_7.1  sepal length (cm)_7.2  sepal length (cm)_7.3  \\\n",
+      "0                    False                  False                  False   \n",
+      "1                    False                  False                  False   \n",
+      "2                    False                  False                  False   \n",
+      "3                    False                  False                  False   \n",
+      "4                    False                  False                  False   \n",
+      "..                     ...                    ...                    ...   \n",
+      "145                  False                  False                  False   \n",
+      "146                  False                  False                  False   \n",
+      "147                  False                  False                  False   \n",
+      "148                  False                  False                  False   \n",
+      "149                  False                  False                  False   \n",
+      "\n",
+      "     sepal length (cm)_7.4  sepal length (cm)_7.6  sepal length (cm)_7.7  \\\n",
+      "0                    False                  False                  False   \n",
+      "1                    False                  False                  False   \n",
+      "2                    False                  False                  False   \n",
+      "3                    False                  False                  False   \n",
+      "4                    False                  False                  False   \n",
+      "..                     ...                    ...                    ...   \n",
+      "145                  False                  False                  False   \n",
+      "146                  False                  False                  False   \n",
+      "147                  False                  False                  False   \n",
+      "148                  False                  False                  False   \n",
+      "149                  False                  False                  False   \n",
+      "\n",
+      "     sepal length (cm)_7.9  \n",
+      "0                    False  \n",
+      "1                    False  \n",
+      "2                    False  \n",
+      "3                    False  \n",
+      "4                    False  \n",
+      "..                     ...  \n",
+      "145                  False  \n",
+      "146                  False  \n",
+      "147                  False  \n",
+      "148                  False  \n",
+      "149                  False  \n",
+      "\n",
+      "[150 rows x 39 columns]\n",
+      "['sepal length (cm)_4.3', 'sepal length (cm)_4.4', 'sepal length (cm)_4.5', 'sepal length (cm)_4.6', 'sepal length (cm)_4.7', 'sepal length (cm)_4.8', 'sepal length (cm)_4.9', 'sepal length (cm)_5.0', 'sepal length (cm)_5.1', 'sepal length (cm)_5.2', 'sepal length (cm)_5.3', 'sepal length (cm)_5.4', 'sepal length (cm)_5.5', 'sepal length (cm)_5.6', 'sepal length (cm)_5.7', 'sepal length (cm)_5.8', 'sepal length (cm)_5.9', 'sepal length (cm)_6.0', 'sepal length (cm)_6.1', 'sepal length (cm)_6.2', 'sepal length (cm)_6.3', 'sepal length (cm)_6.4', 'sepal length (cm)_6.5', 'sepal length (cm)_6.6', 'sepal length (cm)_6.7', 'sepal length (cm)_6.8', 'sepal length (cm)_6.9', 'sepal length (cm)_7.0', 'sepal length (cm)_7.1', 'sepal length (cm)_7.2', 'sepal length (cm)_7.3', 'sepal length (cm)_7.4', 'sepal length (cm)_7.6', 'sepal length (cm)_7.7', 'sepal length (cm)_7.9']\n"
+     ]
+    }
+   ],
+   "source": [
+    "one_hot_df, new_columns = api.one_hot_encode(inplace=False, ignore_target=True, target=\"target\")\n",
+    "print(one_hot_df)\n",
+    "print(new_columns)\n",
+    "one_hot_df, new_columns = api.one_hot_encode(inplace=False, columns=[\"sepal length (cm)\"], ignore_target=True, target=\"target\")\n",
+    "print(one_hot_df)\n",
+    "print(new_columns)"
    ]
   },
   {
@@ -291,22 +440,11 @@
    "execution_count": 7,
    "id": "8d4abbe8-7683-4eaf-9b1f-0da7ed1de76e",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "dataset = \"../Data/archive 2/Iris.csv\"\n",
-    "pd.read_csv(dataset)\n",
-    "api.set_local_csv_dataset(dataset=dataset, concat=True)"
+    "# dataset = \"../Data/archive 2/Iris.csv\"\n",
+    "# pd.read_csv(dataset)\n",
+    "# api.set_local_csv_dataset(dataset=dataset, concat=True)"
    ]
   },
   {
@@ -343,18 +481,9 @@
    "execution_count": 10,
    "id": "140ad41f-0542-4165-bbea-5472962da2e0",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Model Accuracy: 1.0\n",
-      "DecisionTreeClassifier(random_state=42)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "print(api.decision_tree('Species', max_epochs=10))"
+    "# print(api.decision_tree('Species', max_epochs=10))"
    ]
   },
   {
@@ -367,53 +496,38 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "TESTING\n",
+      "encoding categorical data\n",
       "Columns: \n",
-      "[[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150], [5.1, 4.9, 4.7, 4.6, 5.0, 5.4, 4.4, 4.8, 4.3, 5.8, 5.7, 5.2, 5.5, 4.5, 5.3, 7.0, 6.4, 6.9, 6.5, 6.3, 6.6, 5.9, 6.0, 6.1, 5.6, 6.7, 6.2, 6.8, 7.1, 7.6, 7.3, 7.2, 7.7, 7.4, 7.9], [3.5, 3.0, 3.2, 3.1, 3.6, 3.9, 3.4, 2.9, 3.7, 4.0, 4.4, 3.8, 3.3, 4.1, 4.2, 2.3, 2.8, 2.4, 2.7, 2.0, 2.2, 2.5, 2.6], [1.4, 1.3, 1.5, 1.7, 1.6, 1.1, 1.2, 1.0, 1.9, 4.7, 4.5, 4.9, 4.0, 4.6, 3.3, 3.9, 3.5, 4.2, 3.6, 4.4, 4.1, 4.8, 4.3, 5.0, 3.8, 3.7, 5.1, 3.0, 6.0, 5.9, 5.6, 5.8, 6.6, 6.3, 6.1, 5.3, 5.5, 6.7, 6.9, 5.7, 6.4, 5.4, 5.2], [0.2, 0.4, 0.3, 0.1, 0.5, 0.6, 1.4, 1.5, 1.3, 1.6, 1.0, 1.1, 1.8, 1.2, 1.7, 2.5, 1.9, 2.1, 2.2, 2.0, 2.4, 2.3], ['Iris-setosa', 'Iris-versicolor', 'Iris-virginica']]\n"
+      "'Index' object has no attribute 'remove'\n"
      ]
     },
     {
-     "data": {
-      "text/plain": [
-       "(      Id  SepalLengthCm  SepalWidthCm  PetalLengthCm  PetalWidthCm  \\\n",
-       " 0      1            5.1           3.5            1.4           0.2   \n",
-       " 1      2            4.9           3.0            1.4           0.2   \n",
-       " 2      3            4.7           3.2            1.3           0.2   \n",
-       " 3      4            4.6           3.1            1.5           0.2   \n",
-       " 4      5            5.0           3.6            1.4           0.2   \n",
-       " ..   ...            ...           ...            ...           ...   \n",
-       " 145  146            6.7           3.0            5.2           2.3   \n",
-       " 146  147            6.3           2.5            5.0           1.9   \n",
-       " 147  148            6.5           3.0            5.2           2.0   \n",
-       " 148  149            6.2           3.4            5.4           2.3   \n",
-       " 149  150            5.9           3.0            5.1           1.8   \n",
-       " \n",
-       "      Species_Iris-setosa  Species_Iris-versicolor  Species_Iris-virginica  \n",
-       " 0                   True                    False                   False  \n",
-       " 1                   True                    False                   False  \n",
-       " 2                   True                    False                   False  \n",
-       " 3                   True                    False                   False  \n",
-       " 4                   True                    False                   False  \n",
-       " ..                   ...                      ...                     ...  \n",
-       " 145                False                    False                    True  \n",
-       " 146                False                    False                    True  \n",
-       " 147                False                    False                    True  \n",
-       " 148                False                    False                    True  \n",
-       " 149                False                    False                    True  \n",
-       " \n",
-       " [150 rows x 8 columns],\n",
-       " ['Species_Iris-setosa', 'Species_Iris-versicolor', 'Species_Iris-virginica'])"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
+     "ename": "KeyError",
+     "evalue": "'Species'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "File \u001b[0;32m/opt/anaconda3/lib/python3.11/site-packages/pandas/core/indexes/base.py:3805\u001b[0m, in \u001b[0;36mIndex.get_loc\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   3804\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m-> 3805\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_engine\u001b[38;5;241m.\u001b[39mget_loc(casted_key)\n\u001b[1;32m   3806\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m err:\n",
+      "File \u001b[0;32mindex.pyx:167\u001b[0m, in \u001b[0;36mpandas._libs.index.IndexEngine.get_loc\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32mindex.pyx:196\u001b[0m, in \u001b[0;36mpandas._libs.index.IndexEngine.get_loc\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32mpandas/_libs/hashtable_class_helper.pxi:7081\u001b[0m, in \u001b[0;36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32mpandas/_libs/hashtable_class_helper.pxi:7089\u001b[0m, in \u001b[0;36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;31mKeyError\u001b[0m: 'Species'",
+      "\nThe above exception was the direct cause of the following exception:\n",
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[11], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m api\u001b[38;5;241m.\u001b[39mone_hot_encode(inplace\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m, ignore_target\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m, target\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mSpecies\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m----> 2\u001b[0m \u001b[38;5;28mprint\u001b[39m(api\u001b[38;5;241m.\u001b[39mlogistic_regression(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mSpecies\u001b[39m\u001b[38;5;124m'\u001b[39m, max_epochs\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m700\u001b[39m))\n\u001b[1;32m      3\u001b[0m \u001b[38;5;28mprint\u001b[39m(api\u001b[38;5;241m.\u001b[39mlinear_regression(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mSpecies\u001b[39m\u001b[38;5;124m'\u001b[39m, max_epochs\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m10\u001b[39m))\n",
+      "File \u001b[0;32m~/Desktop/School/CollegeCode/COSC480/MLite/src/ML/ML_API.py:181\u001b[0m, in \u001b[0;36mMLAPI.logistic_regression\u001b[0;34m(self, label, lr, test_size, random_state, columns, max_epochs, verbose)\u001b[0m\n\u001b[1;32m    179\u001b[0m     y \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdataset[\u001b[38;5;241m-\u001b[39m\u001b[38;5;241m1\u001b[39m]\n\u001b[1;32m    180\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m--> 181\u001b[0m     y \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdataset[label]\n\u001b[1;32m    183\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m columns \u001b[38;5;241m==\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m    184\u001b[0m     \u001b[38;5;66;03m#assume all other columns and set X_columns to all features not label\u001b[39;00m\n\u001b[1;32m    185\u001b[0m     X_columns \u001b[38;5;241m=\u001b[39m [col \u001b[38;5;28;01mfor\u001b[39;00m col \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdataset\u001b[38;5;241m.\u001b[39mcolumns \u001b[38;5;28;01mif\u001b[39;00m label \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m col]\n",
+      "File \u001b[0;32m/opt/anaconda3/lib/python3.11/site-packages/pandas/core/frame.py:4102\u001b[0m, in \u001b[0;36mDataFrame.__getitem__\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   4100\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mcolumns\u001b[38;5;241m.\u001b[39mnlevels \u001b[38;5;241m>\u001b[39m \u001b[38;5;241m1\u001b[39m:\n\u001b[1;32m   4101\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_getitem_multilevel(key)\n\u001b[0;32m-> 4102\u001b[0m indexer \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mcolumns\u001b[38;5;241m.\u001b[39mget_loc(key)\n\u001b[1;32m   4103\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m is_integer(indexer):\n\u001b[1;32m   4104\u001b[0m     indexer \u001b[38;5;241m=\u001b[39m [indexer]\n",
+      "File \u001b[0;32m/opt/anaconda3/lib/python3.11/site-packages/pandas/core/indexes/base.py:3812\u001b[0m, in \u001b[0;36mIndex.get_loc\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   3807\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(casted_key, \u001b[38;5;28mslice\u001b[39m) \u001b[38;5;129;01mor\u001b[39;00m (\n\u001b[1;32m   3808\u001b[0m         \u001b[38;5;28misinstance\u001b[39m(casted_key, abc\u001b[38;5;241m.\u001b[39mIterable)\n\u001b[1;32m   3809\u001b[0m         \u001b[38;5;129;01mand\u001b[39;00m \u001b[38;5;28many\u001b[39m(\u001b[38;5;28misinstance\u001b[39m(x, \u001b[38;5;28mslice\u001b[39m) \u001b[38;5;28;01mfor\u001b[39;00m x \u001b[38;5;129;01min\u001b[39;00m casted_key)\n\u001b[1;32m   3810\u001b[0m     ):\n\u001b[1;32m   3811\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m InvalidIndexError(key)\n\u001b[0;32m-> 3812\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(key) \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01merr\u001b[39;00m\n\u001b[1;32m   3813\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m:\n\u001b[1;32m   3814\u001b[0m     \u001b[38;5;66;03m# If we have a listlike key, _check_indexing_error will raise\u001b[39;00m\n\u001b[1;32m   3815\u001b[0m     \u001b[38;5;66;03m#  InvalidIndexError. Otherwise we fall through and re-raise\u001b[39;00m\n\u001b[1;32m   3816\u001b[0m     \u001b[38;5;66;03m#  the TypeError.\u001b[39;00m\n\u001b[1;32m   3817\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_check_indexing_error(key)\n",
+      "\u001b[0;31mKeyError\u001b[0m: 'Species'"
+     ]
     }
    ],
    "source": [
-    "api.one_hot_encode()\n",
-    "# print(api.logistic_regression('popularity', max_epochs=700))\n",
-    "# print(api.linear_regression('popularity', max_epochs=10))"
+    "api.one_hot_encode(inplace=True, ignore_target=True, target=\"Species\")\n",
+    "print(api.logistic_regression('Species', max_epochs=700))\n",
+    "print(api.linear_regression('Species', max_epochs=10))"
    ]
   },
   {

--- a/src/ML/ML_API.ipynb
+++ b/src/ML/ML_API.ipynb
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 34,
    "metadata": {
     "id": "EAKwFe1mTfqp"
    },
@@ -60,17 +60,36 @@
     "        except:\n",
     "            return 0\n",
     "\n",
-    "    def one_hot_encode(self, inplace=True, dataset=None, cutoff = 10, columns=None):\n",
+    "    def one_hot_encode(self, inplace=False, cutoff = 10, columns=None, ignore_target=True, target=None):\n",
     "        # TODO: Fix this\n",
     "        \n",
     "        # do a one hot encode of the current dataset and then return \n",
     "        # the new column names alongside the new dataframe\n",
-    "        print(\"TESTING\")\n",
+    "        print(\"encoding categorical data\")\n",
+    "        \n",
     "        try:\n",
     "            print(\"Columns: \")\n",
-    "            print ([self.dataset[col].unique().tolist() for col in self.dataset.columns])\n",
-    "            one_hot_df = pd.get_dummies(self.dataset)\n",
-    "        \n",
+    "            \n",
+    "            if columns != None:\n",
+    "                encode_cols = columns\n",
+    "            else:\n",
+    "                encode_cols = [col for col in self.dataset.columns if self.dataset[col].dtype == 'object']\n",
+    "            try:\n",
+    "                if ignore_target == True and target != None:\n",
+    "                    encode_cols.remove(target)\n",
+    "                else:\n",
+    "                    target = self.dataset.columns.tolist()[-1]\n",
+    "                    del encode_cols[target]\n",
+    "            except:\n",
+    "                print(\"Target variable not in encoding columns.\")\n",
+    "            \n",
+    "            # print ([self.dataset[col].unique().tolist() for col in self.dataset.columns])\n",
+    "            one_hot_df = pd.get_dummies(data=self.dataset, columns=encode_cols)\n",
+    "            if ignore_target == True and target != None:\n",
+    "                pd.concat([one_hot_df, self.dataset[[target]]])\n",
+    "            else:\n",
+    "                pd.concat([one_hot_df, self.dataset.iloc[:,-1:]])\n",
+    "                \n",
     "            new_columns = one_hot_df.columns.difference(self.dataset.columns).tolist()\n",
     "            \n",
     "        # catch when df1 is None\n",
@@ -138,14 +157,16 @@
     "        return r2\n",
     "        \n",
     "    def recommed_model(self, columns, features):\n",
-    "        # should probably mostly rely upon user input to recommend a model\n",
-    "        # if data is linear and wants easy explanation -> linear\n",
-    "        # linear data + categorical data -> logistic regression\n",
-    "        # we can get linearity from R^2 score?\n",
-    "        # high dimensional data + easy explanation or large amount of entries -> decision tree\n",
-    "        # high dimensional data + higher accuracy + fewer entries -> SVM\n",
-    "        # SVM takes longer to train than most trees\n",
-    "        # TODO: add naive bayes algorithm to class\n",
+    "        \"\"\"\n",
+    "        should probably mostly rely upon user input to recommend a model\n",
+    "        if data is linear and wants easy explanation -> linear\n",
+    "        linear data + categorical data -> logistic regression\n",
+    "        we can get linearity from R^2 score?\n",
+    "        high dimensional data + easy explanation or large amount of entries -> decision tree\n",
+    "        high dimensional data + higher accuracy + fewer entries -> SVM\n",
+    "        SVM takes longer to train than most trees\n",
+    "        TODO: add naive bayes algorithm to class\n",
+    "        \"\"\"\n",
     "\n",
     "        X = self.dataset[features].values\n",
     "        y = self.dataset[columns].values.flatten()\n",
@@ -357,7 +378,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -379,14 +400,6 @@
      "traceback": [
       "An exception has occurred, use %tb to see the full traceback.\n",
       "\u001b[0;31mSystemExit\u001b[0m\u001b[0;31m:\u001b[0m 2\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/anaconda3/lib/python3.11/site-packages/IPython/core/interactiveshell.py:3516: UserWarning: To exit: use 'exit', 'quit', or Ctrl-D.\n",
-      "  warn(\"To exit: use 'exit', 'quit', or Ctrl-D.\", stacklevel=1)\n"
      ]
     }
    ],
@@ -436,7 +449,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
@@ -444,7 +457,7 @@
      "output_type": "stream",
      "text": [
       "[NbConvertApp] Converting notebook ML_API.ipynb to script\n",
-      "[NbConvertApp] Writing 15185 bytes to ML_API.py\n"
+      "[NbConvertApp] Writing 16109 bytes to ML_API.py\n"
      ]
     }
    ],

--- a/src/ML/ML_API.py
+++ b/src/ML/ML_API.py
@@ -19,7 +19,7 @@ import argparse
 from sklearn.neural_network import MLPClassifier, MLPRegressor
 
 
-# In[1]:
+# In[34]:
 
 
 class MLAPI:
@@ -51,17 +51,36 @@ class MLAPI:
         except:
             return 0
 
-    def one_hot_encode(self, inplace=True, dataset=None, cutoff = 10, columns=None):
+    def one_hot_encode(self, inplace=False, cutoff = 10, columns=None, ignore_target=True, target=None):
         # TODO: Fix this
         
         # do a one hot encode of the current dataset and then return 
         # the new column names alongside the new dataframe
-        print("TESTING")
+        print("encoding categorical data")
+        
         try:
             print("Columns: ")
-            print ([self.dataset[col].unique().tolist() for col in self.dataset.columns])
-            one_hot_df = pd.get_dummies(self.dataset)
-        
+            
+            if columns != None:
+                encode_cols = columns
+            else:
+                encode_cols = [col for col in self.dataset.columns if self.dataset[col].dtype == 'object']
+            try:
+                if ignore_target == True and target != None:
+                    encode_cols.remove(target)
+                else:
+                    target = self.dataset.columns.tolist()[-1]
+                    del encode_cols[target]
+            except:
+                print("Target variable not in encoding columns.")
+            
+            # print ([self.dataset[col].unique().tolist() for col in self.dataset.columns])
+            one_hot_df = pd.get_dummies(data=self.dataset, columns=encode_cols)
+            if ignore_target == True and target != None:
+                pd.concat([one_hot_df, self.dataset[[target]]])
+            else:
+                pd.concat([one_hot_df, self.dataset.iloc[:,-1:]])
+                
             new_columns = one_hot_df.columns.difference(self.dataset.columns).tolist()
             
         # catch when df1 is None
@@ -129,14 +148,16 @@ class MLAPI:
         return r2
         
     def recommed_model(self, columns, features):
-        # should probably mostly rely upon user input to recommend a model
-        # if data is linear and wants easy explanation -> linear
-        # linear data + categorical data -> logistic regression
-        # we can get linearity from R^2 score?
-        # high dimensional data + easy explanation or large amount of entries -> decision tree
-        # high dimensional data + higher accuracy + fewer entries -> SVM
-        # SVM takes longer to train than most trees
-        # TODO: add naive bayes algorithm to class
+        """
+        should probably mostly rely upon user input to recommend a model
+        if data is linear and wants easy explanation -> linear
+        linear data + categorical data -> logistic regression
+        we can get linearity from R^2 score?
+        high dimensional data + easy explanation or large amount of entries -> decision tree
+        high dimensional data + higher accuracy + fewer entries -> SVM
+        SVM takes longer to train than most trees
+        TODO: add naive bayes algorithm to class
+        """
 
         X = self.dataset[features].values
         y = self.dataset[columns].values.flatten()
@@ -346,7 +367,7 @@ class MLAPI:
                 
 
 
-# In[3]:
+# In[32]:
 
 
 if __name__ == "__main__":
@@ -392,7 +413,7 @@ if __name__ == "__main__":
         print("Invalid task specified. Use --help for options.")
 
 
-# In[9]:
+# In[37]:
 
 
 get_ipython().system("jupyter nbconvert --to script 'ML_API.ipynb'")

--- a/src/ML/ML_test.ipynb
+++ b/src/ML/ML_test.ipynb
@@ -11,7 +11,7 @@
      "output_type": "stream",
      "text": [
       "[NbConvertApp] Converting notebook ML_API.ipynb to script\n",
-      "[NbConvertApp] Writing 15185 bytes to ML_API.py\n"
+      "[NbConvertApp] Writing 16045 bytes to ML_API.py\n"
      ]
     }
    ],
@@ -71,6 +71,155 @@
     "api = MLAPI()\n",
     "api.set_local_csv_dataset()\n",
     "print(api.dataset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "1a5c7d4e-4e2a-41cf-8084-80809dcc72a3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "encoding categorical data\n",
+      "Columns: \n",
+      "Target variable not in encoding columns.\n",
+      "     sepal length (cm)  sepal width (cm)  petal length (cm)  petal width (cm)  \\\n",
+      "0                  5.1               3.5                1.4               0.2   \n",
+      "1                  4.9               3.0                1.4               0.2   \n",
+      "2                  4.7               3.2                1.3               0.2   \n",
+      "3                  4.6               3.1                1.5               0.2   \n",
+      "4                  5.0               3.6                1.4               0.2   \n",
+      "..                 ...               ...                ...               ...   \n",
+      "145                6.7               3.0                5.2               2.3   \n",
+      "146                6.3               2.5                5.0               1.9   \n",
+      "147                6.5               3.0                5.2               2.0   \n",
+      "148                6.2               3.4                5.4               2.3   \n",
+      "149                5.9               3.0                5.1               1.8   \n",
+      "\n",
+      "     target  \n",
+      "0       0.0  \n",
+      "1       0.0  \n",
+      "2       0.0  \n",
+      "3       0.0  \n",
+      "4       0.0  \n",
+      "..      ...  \n",
+      "145     2.0  \n",
+      "146     2.0  \n",
+      "147     2.0  \n",
+      "148     2.0  \n",
+      "149     2.0  \n",
+      "\n",
+      "[150 rows x 5 columns]\n",
+      "[]\n",
+      "encoding categorical data\n",
+      "Columns: \n",
+      "Target variable not in encoding columns.\n",
+      "     sepal width (cm)  petal length (cm)  petal width (cm)  target  \\\n",
+      "0                 3.5                1.4               0.2     0.0   \n",
+      "1                 3.0                1.4               0.2     0.0   \n",
+      "2                 3.2                1.3               0.2     0.0   \n",
+      "3                 3.1                1.5               0.2     0.0   \n",
+      "4                 3.6                1.4               0.2     0.0   \n",
+      "..                ...                ...               ...     ...   \n",
+      "145               3.0                5.2               2.3     2.0   \n",
+      "146               2.5                5.0               1.9     2.0   \n",
+      "147               3.0                5.2               2.0     2.0   \n",
+      "148               3.4                5.4               2.3     2.0   \n",
+      "149               3.0                5.1               1.8     2.0   \n",
+      "\n",
+      "     sepal length (cm)_4.3  sepal length (cm)_4.4  sepal length (cm)_4.5  \\\n",
+      "0                    False                  False                  False   \n",
+      "1                    False                  False                  False   \n",
+      "2                    False                  False                  False   \n",
+      "3                    False                  False                  False   \n",
+      "4                    False                  False                  False   \n",
+      "..                     ...                    ...                    ...   \n",
+      "145                  False                  False                  False   \n",
+      "146                  False                  False                  False   \n",
+      "147                  False                  False                  False   \n",
+      "148                  False                  False                  False   \n",
+      "149                  False                  False                  False   \n",
+      "\n",
+      "     sepal length (cm)_4.6  sepal length (cm)_4.7  sepal length (cm)_4.8  ...  \\\n",
+      "0                    False                  False                  False  ...   \n",
+      "1                    False                  False                  False  ...   \n",
+      "2                    False                   True                  False  ...   \n",
+      "3                     True                  False                  False  ...   \n",
+      "4                    False                  False                  False  ...   \n",
+      "..                     ...                    ...                    ...  ...   \n",
+      "145                  False                  False                  False  ...   \n",
+      "146                  False                  False                  False  ...   \n",
+      "147                  False                  False                  False  ...   \n",
+      "148                  False                  False                  False  ...   \n",
+      "149                  False                  False                  False  ...   \n",
+      "\n",
+      "     sepal length (cm)_6.8  sepal length (cm)_6.9  sepal length (cm)_7.0  \\\n",
+      "0                    False                  False                  False   \n",
+      "1                    False                  False                  False   \n",
+      "2                    False                  False                  False   \n",
+      "3                    False                  False                  False   \n",
+      "4                    False                  False                  False   \n",
+      "..                     ...                    ...                    ...   \n",
+      "145                  False                  False                  False   \n",
+      "146                  False                  False                  False   \n",
+      "147                  False                  False                  False   \n",
+      "148                  False                  False                  False   \n",
+      "149                  False                  False                  False   \n",
+      "\n",
+      "     sepal length (cm)_7.1  sepal length (cm)_7.2  sepal length (cm)_7.3  \\\n",
+      "0                    False                  False                  False   \n",
+      "1                    False                  False                  False   \n",
+      "2                    False                  False                  False   \n",
+      "3                    False                  False                  False   \n",
+      "4                    False                  False                  False   \n",
+      "..                     ...                    ...                    ...   \n",
+      "145                  False                  False                  False   \n",
+      "146                  False                  False                  False   \n",
+      "147                  False                  False                  False   \n",
+      "148                  False                  False                  False   \n",
+      "149                  False                  False                  False   \n",
+      "\n",
+      "     sepal length (cm)_7.4  sepal length (cm)_7.6  sepal length (cm)_7.7  \\\n",
+      "0                    False                  False                  False   \n",
+      "1                    False                  False                  False   \n",
+      "2                    False                  False                  False   \n",
+      "3                    False                  False                  False   \n",
+      "4                    False                  False                  False   \n",
+      "..                     ...                    ...                    ...   \n",
+      "145                  False                  False                  False   \n",
+      "146                  False                  False                  False   \n",
+      "147                  False                  False                  False   \n",
+      "148                  False                  False                  False   \n",
+      "149                  False                  False                  False   \n",
+      "\n",
+      "     sepal length (cm)_7.9  \n",
+      "0                    False  \n",
+      "1                    False  \n",
+      "2                    False  \n",
+      "3                    False  \n",
+      "4                    False  \n",
+      "..                     ...  \n",
+      "145                  False  \n",
+      "146                  False  \n",
+      "147                  False  \n",
+      "148                  False  \n",
+      "149                  False  \n",
+      "\n",
+      "[150 rows x 39 columns]\n",
+      "['sepal length (cm)_4.3', 'sepal length (cm)_4.4', 'sepal length (cm)_4.5', 'sepal length (cm)_4.6', 'sepal length (cm)_4.7', 'sepal length (cm)_4.8', 'sepal length (cm)_4.9', 'sepal length (cm)_5.0', 'sepal length (cm)_5.1', 'sepal length (cm)_5.2', 'sepal length (cm)_5.3', 'sepal length (cm)_5.4', 'sepal length (cm)_5.5', 'sepal length (cm)_5.6', 'sepal length (cm)_5.7', 'sepal length (cm)_5.8', 'sepal length (cm)_5.9', 'sepal length (cm)_6.0', 'sepal length (cm)_6.1', 'sepal length (cm)_6.2', 'sepal length (cm)_6.3', 'sepal length (cm)_6.4', 'sepal length (cm)_6.5', 'sepal length (cm)_6.6', 'sepal length (cm)_6.7', 'sepal length (cm)_6.8', 'sepal length (cm)_6.9', 'sepal length (cm)_7.0', 'sepal length (cm)_7.1', 'sepal length (cm)_7.2', 'sepal length (cm)_7.3', 'sepal length (cm)_7.4', 'sepal length (cm)_7.6', 'sepal length (cm)_7.7', 'sepal length (cm)_7.9']\n"
+     ]
+    }
+   ],
+   "source": [
+    "one_hot_df, new_columns = api.one_hot_encode(inplace=False, ignore_target=True, target=\"target\")\n",
+    "print(one_hot_df)\n",
+    "print(new_columns)\n",
+    "one_hot_df, new_columns = api.one_hot_encode(inplace=False, columns=[\"sepal length (cm)\"], ignore_target=True, target=\"target\")\n",
+    "print(one_hot_df)\n",
+    "print(new_columns)"
    ]
   },
   {
@@ -291,22 +440,11 @@
    "execution_count": 7,
    "id": "8d4abbe8-7683-4eaf-9b1f-0da7ed1de76e",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "dataset = \"../Data/archive 2/Iris.csv\"\n",
-    "pd.read_csv(dataset)\n",
-    "api.set_local_csv_dataset(dataset=dataset, concat=True)"
+    "# dataset = \"../Data/archive 2/Iris.csv\"\n",
+    "# pd.read_csv(dataset)\n",
+    "# api.set_local_csv_dataset(dataset=dataset, concat=True)"
    ]
   },
   {
@@ -343,18 +481,9 @@
    "execution_count": 10,
    "id": "140ad41f-0542-4165-bbea-5472962da2e0",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Model Accuracy: 1.0\n",
-      "DecisionTreeClassifier(random_state=42)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "print(api.decision_tree('Species', max_epochs=10))"
+    "# print(api.decision_tree('Species', max_epochs=10))"
    ]
   },
   {
@@ -367,53 +496,38 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "TESTING\n",
+      "encoding categorical data\n",
       "Columns: \n",
-      "[[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150], [5.1, 4.9, 4.7, 4.6, 5.0, 5.4, 4.4, 4.8, 4.3, 5.8, 5.7, 5.2, 5.5, 4.5, 5.3, 7.0, 6.4, 6.9, 6.5, 6.3, 6.6, 5.9, 6.0, 6.1, 5.6, 6.7, 6.2, 6.8, 7.1, 7.6, 7.3, 7.2, 7.7, 7.4, 7.9], [3.5, 3.0, 3.2, 3.1, 3.6, 3.9, 3.4, 2.9, 3.7, 4.0, 4.4, 3.8, 3.3, 4.1, 4.2, 2.3, 2.8, 2.4, 2.7, 2.0, 2.2, 2.5, 2.6], [1.4, 1.3, 1.5, 1.7, 1.6, 1.1, 1.2, 1.0, 1.9, 4.7, 4.5, 4.9, 4.0, 4.6, 3.3, 3.9, 3.5, 4.2, 3.6, 4.4, 4.1, 4.8, 4.3, 5.0, 3.8, 3.7, 5.1, 3.0, 6.0, 5.9, 5.6, 5.8, 6.6, 6.3, 6.1, 5.3, 5.5, 6.7, 6.9, 5.7, 6.4, 5.4, 5.2], [0.2, 0.4, 0.3, 0.1, 0.5, 0.6, 1.4, 1.5, 1.3, 1.6, 1.0, 1.1, 1.8, 1.2, 1.7, 2.5, 1.9, 2.1, 2.2, 2.0, 2.4, 2.3], ['Iris-setosa', 'Iris-versicolor', 'Iris-virginica']]\n"
+      "'Index' object has no attribute 'remove'\n"
      ]
     },
     {
-     "data": {
-      "text/plain": [
-       "(      Id  SepalLengthCm  SepalWidthCm  PetalLengthCm  PetalWidthCm  \\\n",
-       " 0      1            5.1           3.5            1.4           0.2   \n",
-       " 1      2            4.9           3.0            1.4           0.2   \n",
-       " 2      3            4.7           3.2            1.3           0.2   \n",
-       " 3      4            4.6           3.1            1.5           0.2   \n",
-       " 4      5            5.0           3.6            1.4           0.2   \n",
-       " ..   ...            ...           ...            ...           ...   \n",
-       " 145  146            6.7           3.0            5.2           2.3   \n",
-       " 146  147            6.3           2.5            5.0           1.9   \n",
-       " 147  148            6.5           3.0            5.2           2.0   \n",
-       " 148  149            6.2           3.4            5.4           2.3   \n",
-       " 149  150            5.9           3.0            5.1           1.8   \n",
-       " \n",
-       "      Species_Iris-setosa  Species_Iris-versicolor  Species_Iris-virginica  \n",
-       " 0                   True                    False                   False  \n",
-       " 1                   True                    False                   False  \n",
-       " 2                   True                    False                   False  \n",
-       " 3                   True                    False                   False  \n",
-       " 4                   True                    False                   False  \n",
-       " ..                   ...                      ...                     ...  \n",
-       " 145                False                    False                    True  \n",
-       " 146                False                    False                    True  \n",
-       " 147                False                    False                    True  \n",
-       " 148                False                    False                    True  \n",
-       " 149                False                    False                    True  \n",
-       " \n",
-       " [150 rows x 8 columns],\n",
-       " ['Species_Iris-setosa', 'Species_Iris-versicolor', 'Species_Iris-virginica'])"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
+     "ename": "KeyError",
+     "evalue": "'Species'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "File \u001b[0;32m/opt/anaconda3/lib/python3.11/site-packages/pandas/core/indexes/base.py:3805\u001b[0m, in \u001b[0;36mIndex.get_loc\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   3804\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m-> 3805\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_engine\u001b[38;5;241m.\u001b[39mget_loc(casted_key)\n\u001b[1;32m   3806\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m err:\n",
+      "File \u001b[0;32mindex.pyx:167\u001b[0m, in \u001b[0;36mpandas._libs.index.IndexEngine.get_loc\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32mindex.pyx:196\u001b[0m, in \u001b[0;36mpandas._libs.index.IndexEngine.get_loc\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32mpandas/_libs/hashtable_class_helper.pxi:7081\u001b[0m, in \u001b[0;36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32mpandas/_libs/hashtable_class_helper.pxi:7089\u001b[0m, in \u001b[0;36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;31mKeyError\u001b[0m: 'Species'",
+      "\nThe above exception was the direct cause of the following exception:\n",
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[11], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m api\u001b[38;5;241m.\u001b[39mone_hot_encode(inplace\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m, ignore_target\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m, target\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mSpecies\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m----> 2\u001b[0m \u001b[38;5;28mprint\u001b[39m(api\u001b[38;5;241m.\u001b[39mlogistic_regression(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mSpecies\u001b[39m\u001b[38;5;124m'\u001b[39m, max_epochs\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m700\u001b[39m))\n\u001b[1;32m      3\u001b[0m \u001b[38;5;28mprint\u001b[39m(api\u001b[38;5;241m.\u001b[39mlinear_regression(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mSpecies\u001b[39m\u001b[38;5;124m'\u001b[39m, max_epochs\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m10\u001b[39m))\n",
+      "File \u001b[0;32m~/Desktop/School/CollegeCode/COSC480/MLite/src/ML/ML_API.py:181\u001b[0m, in \u001b[0;36mMLAPI.logistic_regression\u001b[0;34m(self, label, lr, test_size, random_state, columns, max_epochs, verbose)\u001b[0m\n\u001b[1;32m    179\u001b[0m     y \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdataset[\u001b[38;5;241m-\u001b[39m\u001b[38;5;241m1\u001b[39m]\n\u001b[1;32m    180\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m--> 181\u001b[0m     y \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdataset[label]\n\u001b[1;32m    183\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m columns \u001b[38;5;241m==\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m    184\u001b[0m     \u001b[38;5;66;03m#assume all other columns and set X_columns to all features not label\u001b[39;00m\n\u001b[1;32m    185\u001b[0m     X_columns \u001b[38;5;241m=\u001b[39m [col \u001b[38;5;28;01mfor\u001b[39;00m col \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdataset\u001b[38;5;241m.\u001b[39mcolumns \u001b[38;5;28;01mif\u001b[39;00m label \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m col]\n",
+      "File \u001b[0;32m/opt/anaconda3/lib/python3.11/site-packages/pandas/core/frame.py:4102\u001b[0m, in \u001b[0;36mDataFrame.__getitem__\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   4100\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mcolumns\u001b[38;5;241m.\u001b[39mnlevels \u001b[38;5;241m>\u001b[39m \u001b[38;5;241m1\u001b[39m:\n\u001b[1;32m   4101\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_getitem_multilevel(key)\n\u001b[0;32m-> 4102\u001b[0m indexer \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mcolumns\u001b[38;5;241m.\u001b[39mget_loc(key)\n\u001b[1;32m   4103\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m is_integer(indexer):\n\u001b[1;32m   4104\u001b[0m     indexer \u001b[38;5;241m=\u001b[39m [indexer]\n",
+      "File \u001b[0;32m/opt/anaconda3/lib/python3.11/site-packages/pandas/core/indexes/base.py:3812\u001b[0m, in \u001b[0;36mIndex.get_loc\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   3807\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(casted_key, \u001b[38;5;28mslice\u001b[39m) \u001b[38;5;129;01mor\u001b[39;00m (\n\u001b[1;32m   3808\u001b[0m         \u001b[38;5;28misinstance\u001b[39m(casted_key, abc\u001b[38;5;241m.\u001b[39mIterable)\n\u001b[1;32m   3809\u001b[0m         \u001b[38;5;129;01mand\u001b[39;00m \u001b[38;5;28many\u001b[39m(\u001b[38;5;28misinstance\u001b[39m(x, \u001b[38;5;28mslice\u001b[39m) \u001b[38;5;28;01mfor\u001b[39;00m x \u001b[38;5;129;01min\u001b[39;00m casted_key)\n\u001b[1;32m   3810\u001b[0m     ):\n\u001b[1;32m   3811\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m InvalidIndexError(key)\n\u001b[0;32m-> 3812\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(key) \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01merr\u001b[39;00m\n\u001b[1;32m   3813\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m:\n\u001b[1;32m   3814\u001b[0m     \u001b[38;5;66;03m# If we have a listlike key, _check_indexing_error will raise\u001b[39;00m\n\u001b[1;32m   3815\u001b[0m     \u001b[38;5;66;03m#  InvalidIndexError. Otherwise we fall through and re-raise\u001b[39;00m\n\u001b[1;32m   3816\u001b[0m     \u001b[38;5;66;03m#  the TypeError.\u001b[39;00m\n\u001b[1;32m   3817\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_check_indexing_error(key)\n",
+      "\u001b[0;31mKeyError\u001b[0m: 'Species'"
+     ]
     }
    ],
    "source": [
-    "api.one_hot_encode()\n",
-    "# print(api.logistic_regression('popularity', max_epochs=700))\n",
-    "# print(api.linear_regression('popularity', max_epochs=10))"
+    "api.one_hot_encode(inplace=True, ignore_target=True, target=\"Species\")\n",
+    "print(api.logistic_regression('Species', max_epochs=700))\n",
+    "print(api.linear_regression('Species', max_epochs=10))"
    ]
   },
   {


### PR DESCRIPTION
#55 
- made inplace not true by default
- added optional arguments to ignore target and pick target column
- one hot encode now works by picking out the categorical columns by default unless passed a list of columns to encode, and will ignore the target columns (assumed to be the final column, unless argument is provided), as sklearn handles categorical predictions fine
