### PR TITLE
Modified the styling for a few pages

### DIFF
--- a/mlite_rails_app/app/views/datasets/_dataset.html.erb
+++ b/mlite_rails_app/app/views/datasets/_dataset.html.erb
@@ -1,17 +1,18 @@
-<div id="<%= dom_id dataset %>" class="card bg-base-100 shadow-xl">
+<div id="<%= dom_id dataset %>" class="card bg-base-100 shadow-xl w-full max-w-full">
   <div class="card-body">
-    <div class="flex flex-row items-center justify-between w-full">
-      <h2 class="card-title text-primary"><%= dataset.name %></h2>
+    <div class="flex flex-wrap items-center justify-between w-full">
+      <h2 class="card-title text-primary w-full md:w-auto truncate" style="max-width: calc(100% - 1rem);"><%= dataset.name %></h2>
 
-      <div><strong>Created:</strong>
+      <div class="w-full md:w-auto"><strong>Created:</strong>
         <%= time_tag dataset.created_at, time_ago_in_words(dataset.created_at) + " ago", title: dataset.created_at.strftime("%B %d, %Y %I:%M %p") %>
       </div>
     </div>
 
-    <p><strong>Description:</strong> <%= dataset.description %></p>
+    <!-- Description Section with Word Break -->
+    <p><strong>Description:</strong> <span class="break-words"><%= dataset.description %></span></p>
 
-    <div class="flex flex-row items-start gap-10">
-      <div class="flex flex-col justify-start">
+    <div class="flex flex-wrap gap-10 w-full">
+      <div class="flex flex-col justify-start w-full sm:w-auto">
         <p><strong>Size:</strong> <%= human_readable_size(dataset.size) %></p>
         <p><strong>Columns:</strong> <%= dataset.columns.map { |col| col["name"] }.join(", ") %></p>
         <p><strong>N rows:</strong> <%= dataset.n_rows %></p>
@@ -19,7 +20,7 @@
       </div>
     </div>
 
-    <div class="card-actions justify-end">
+    <div class="card-actions justify-end flex-wrap w-full">
       <%= link_to edit_dataset_path(dataset), class: "btn text-secondary flex items-center justify-center space-x-2" do %>
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
           <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
@@ -31,9 +32,7 @@
         </svg>
       <% end %>
 
-      <div class="px-3"></div>
-
-      <div class="w-15 flex flex-col items-end gap-2">
+      <div class="w-full md:w-auto flex flex-col items-end gap-2">
         <% if dataset.file.attached? %>
           <%= link_to rails_blob_path(dataset.file, disposition: "attachment"), class: "btn text-primary flex items-center justify-center space-x-2" do %>
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
@@ -43,11 +42,11 @@
         <% end %>
       </div>
 
-      <%= link_to dataset_path(dataset), class: "btn btn-primary" do %>
+      <%= link_to dataset_path(dataset), class: "btn btn-primary w-full sm:w-auto" do %>
         Show Dataset
       <% end %>
 
-      <%= link_to new_model_path(model: {dataset_id: dataset.id}), class: "btn btn-primary" do %>
+      <%= link_to new_model_path(model: {dataset_id: dataset.id}), class: "btn btn-primary w-full sm:w-auto" do %>
         Train a Model
       <% end %>
     </div>

--- a/mlite_rails_app/app/views/datasets/_dataset.html.erb
+++ b/mlite_rails_app/app/views/datasets/_dataset.html.erb
@@ -1,18 +1,21 @@
-<div id="<%= dom_id dataset %>" class="card bg-base-100 shadow-xl w-full max-w-full">
+<div id="<%= dom_id dataset %>" class="card bg-base-100 shadow-xl" style="min-width: 700px; max-width: 700px">
   <div class="card-body">
-    <div class="flex flex-wrap items-center justify-between w-full">
-      <h2 class="card-title text-primary w-full md:w-auto truncate" style="max-width: calc(100% - 1rem);"><%= dataset.name %></h2>
+    <div class="flex flex-row items-center justify-between w-full">
+      <h2 class="card-title text-primary"><%= dataset.name %></h2>
 
-      <div class="w-full md:w-auto"><strong>Created:</strong>
+      <div><strong>Created:</strong>
         <%= time_tag dataset.created_at, time_ago_in_words(dataset.created_at) + " ago", title: dataset.created_at.strftime("%B %d, %Y %I:%M %p") %>
       </div>
     </div>
 
-    <!-- Description Section with Word Break -->
-    <p><strong>Description:</strong> <span class="break-words"><%= dataset.description %></span></p>
+    <hr class="text-primary my-2">
 
-    <div class="flex flex-wrap gap-10 w-full">
-      <div class="flex flex-col justify-start w-full sm:w-auto">
+    <% if dataset.description.present? %>
+      <p><strong>Description:</strong> <%= dataset.description %></p>
+    <% end %>
+
+    <div class="flex flex-row items-start gap-10">
+      <div class="flex flex-col justify-start">
         <p><strong>Size:</strong> <%= human_readable_size(dataset.size) %></p>
         <p><strong>Columns:</strong> <%= dataset.columns.map { |col| col["name"] }.join(", ") %></p>
         <p><strong>N rows:</strong> <%= dataset.n_rows %></p>
@@ -20,7 +23,7 @@
       </div>
     </div>
 
-    <div class="card-actions justify-end flex-wrap w-full">
+    <div class="card-actions justify-center">
       <%= link_to edit_dataset_path(dataset), class: "btn text-secondary flex items-center justify-center space-x-2" do %>
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
           <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
@@ -32,7 +35,9 @@
         </svg>
       <% end %>
 
-      <div class="w-full md:w-auto flex flex-col items-end gap-2">
+      <div class="px-3"></div>
+
+      <div class="w-15 flex flex-col items-end gap-2">
         <% if dataset.file.attached? %>
           <%= link_to rails_blob_path(dataset.file, disposition: "attachment"), class: "btn text-primary flex items-center justify-center space-x-2" do %>
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
@@ -42,11 +47,16 @@
         <% end %>
       </div>
 
-      <%= link_to dataset_path(dataset), class: "btn btn-primary w-full sm:w-auto" do %>
-        Show Dataset
+      <%= link_to dataset_path(dataset), class: "btn text-primary flex items-center justify-center space-x-2" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+        </svg>
       <% end %>
 
-      <%= link_to new_model_path(model: {dataset_id: dataset.id}), class: "btn btn-primary w-full sm:w-auto" do %>
+      <div class="px-3"></div>
+
+      <%= link_to new_model_path(model: {dataset_id: dataset.id}), class: "btn btn-primary" do %>
         Train a Model
       <% end %>
     </div>

--- a/mlite_rails_app/app/views/deployments/_deployment.html.erb
+++ b/mlite_rails_app/app/views/deployments/_deployment.html.erb
@@ -1,8 +1,8 @@
-<div id="<%= dom_id deployment %>" class="card bg-base-100 shadow-xl">
+<div id="<%= dom_id deployment %>" class="card bg-base-100 shadow-xl w-full max-w-full">
   <div class="card-body">
-    <div class="flex flex-row items-center justify-between w-full gap-5">
-      <h2 class="card-title text-primary"><%= deployment.name %></h2>
-      <div class="w-15 flex flex-col justify-start items-end gap-2 w-50">
+    <div class="flex flex-wrap items-center justify-between w-full gap-5">
+      <h2 class="card-title text-primary w-full sm:w-auto truncate"><%= deployment.name %></h2>
+      <div class="w-full sm:w-50 flex flex-col justify-start items-end gap-2">
         <span class="<%= case deployment.status
                          when 'deployed' then 'bg-success text-success-content'
                          when 'in-progress' then 'bg-warning text-warning-content'
@@ -16,9 +16,7 @@
       </div>
     </div>
 
-
-
-    <div class="flex flex-row mt-5 card-actions justify-end">
+    <div class="flex flex-wrap mt-5 card-actions justify-end gap-3">
       <%= link_to edit_deployment_path(deployment), class: "btn text-secondary flex items-center justify-center space-x-2" do %>
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
           <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
@@ -32,7 +30,7 @@
 
       <div class="px-3"></div>
 
-      <div class="card-actions justify-end">
+      <div class="card-actions justify-end w-full sm:w-auto">
         <%= link_to "Run Inference", inference_deployment_path(deployment), class: "btn btn-primary flex items-center justify-center space-x-2" %>
       </div>
 

--- a/mlite_rails_app/app/views/deployments/_deployment.html.erb
+++ b/mlite_rails_app/app/views/deployments/_deployment.html.erb
@@ -1,8 +1,8 @@
-<div id="<%= dom_id deployment %>" class="card bg-base-100 shadow-xl w-full max-w-full">
+<div id="<%= dom_id deployment %>" class="card bg-base-100 shadow-xl" style="min-width: 500px; max-width: 500px">
   <div class="card-body">
-    <div class="flex flex-wrap items-center justify-between w-full gap-5">
-      <h2 class="card-title text-primary w-full sm:w-auto truncate"><%= deployment.name %></h2>
-      <div class="w-full sm:w-50 flex flex-col justify-start items-end gap-2">
+    <div class="flex flex-row items-center justify-between w-full gap-5">
+      <h2 class="card-title text-primary"><%= deployment.name %></h2>
+      <div class="w-15 flex flex-col justify-start items-end gap-2 w-50">
         <span class="<%= case deployment.status
                          when 'deployed' then 'bg-success text-success-content'
                          when 'in-progress' then 'bg-warning text-warning-content'
@@ -16,7 +16,9 @@
       </div>
     </div>
 
-    <div class="flex flex-wrap mt-5 card-actions justify-end gap-3">
+    <hr class="text-primary my-2">
+
+    <div class="flex flex-row mt-2 card-actions justify-center">
       <%= link_to edit_deployment_path(deployment), class: "btn text-secondary flex items-center justify-center space-x-2" do %>
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
           <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
@@ -30,7 +32,7 @@
 
       <div class="px-3"></div>
 
-      <div class="card-actions justify-end w-full sm:w-auto">
+      <div class="card-actions justify-end">
         <%= link_to "Run Inference", inference_deployment_path(deployment), class: "btn btn-primary flex items-center justify-center space-x-2" %>
       </div>
 

--- a/mlite_rails_app/app/views/devise/confirmations/new.html.erb
+++ b/mlite_rails_app/app/views/devise/confirmations/new.html.erb
@@ -1,16 +1,27 @@
-<h2>Resend confirmation instructions</h2>
-
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+<div class="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
+  <div class="sm:mx-auto sm:w-full sm:max-w-sm">
+    <img class="mx-auto h-10 w-auto" src="https://tailwindui.com/plus/img/logos/mark.svg?color=indigo&shade=600" alt="Your Company">
+    <h2 class="mt-10 text-center text-2xl font-bold tracking-tight text-gray-900">Resend confirmation instructions</h2>
   </div>
 
-  <div class="actions">
-    <%= f.submit "Resend confirmation instructions" %>
-  </div>
-<% end %>
+  <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
+    <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, class: 'space-y-6' }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
 
-<%= render "devise/shared/links" %>
+      <div>
+        <label for="email" class="block text-sm font-medium text-gray-900">Email address</label>
+        <div class="mt-2">
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm p-3" %>
+        </div>
+      </div>
+
+      <div>
+        <%= f.submit "Resend confirmation instructions", class: "flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="mt-6 text-center">
+    <%= render "devise/shared/links" %>
+  </div>
+</div>

--- a/mlite_rails_app/app/views/devise/passwords/edit.html.erb
+++ b/mlite_rails_app/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,38 @@
-<h2>Change your password</h2>
+<div class="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
+  <div class="sm:mx-auto sm:w-full sm:max-w-sm">
+    <img class="mx-auto h-10 w-auto" src="https://tailwindui.com/plus/img/logos/mark.svg?color=indigo&shade=600" alt="Your Company">
+    <h2 class="mt-10 text-center text-2xl font-bold tracking-tight text-gray-900">Change your password</h2>
+  </div>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+  <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: 'space-y-6' }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+      <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+      <div>
+        <label for="password" class="block text-sm font-medium text-gray-900">New password</label>
+        <% if @minimum_password_length %>
+          <em class="text-xs text-gray-500">( <%= @minimum_password_length %> characters minimum )</em><br />
+        <% end %>
+        <div class="mt-2">
+          <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm p-3" %>
+        </div>
+      </div>
+
+      <div>
+        <label for="password_confirmation" class="block text-sm font-medium text-gray-900">Confirm new password</label>
+        <div class="mt-2">
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm p-3" %>
+        </div>
+      </div>
+
+      <div>
+        <button type="submit" class="flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Change my password</button>
+      </div>
     <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
   </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  <div class="mt-6 text-center">
+    <%= render "devise/shared/links" %>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/mlite_rails_app/app/views/devise/shared/_links.html.erb
+++ b/mlite_rails_app/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,40 @@
-<%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
-<% end %>
+ <div class="sm:mx-auto sm:w-full sm:max-w-sm space-y-6">
+    <%- if controller_name != 'sessions' %>
+      <div>
+        <%= link_to "Log in", new_session_path(resource_name), class: "block w-full text-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
+      </div>
+    <%- end %>
 
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
-<% end %>
+    <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+      <div>
+        <%= link_to "Sign up", new_registration_path(resource_name), class: "block w-full text-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
+      </div>
+    <%- end %>
 
-<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
-<% end %>
+    <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+      <div>
+        <%= link_to "Forgot your password?", new_password_path(resource_name), class: "block w-full text-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
+      </div>
+    <%- end %>
 
-<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
-<% end %>
+    <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+      <div>
+        <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name), class: "block w-full text-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
+      </div>
+    <%- end %>
 
-<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
-<% end %>
+    <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+      <div>
+        <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name), class: "block w-full text-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
+      </div>
+    <%- end %>
 
-<%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
-  <% end %>
-<% end %>
+    <%- if devise_mapping.omniauthable? %>
+      <%- resource_class.omniauth_providers.each do |provider| %>
+        <div>
+          <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), class: "w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600", data: { turbo: false } %>
+        </div>
+      <% end %>
+    <%- end %>
+  </div>
+</div>

--- a/mlite_rails_app/app/views/devise/shared/_links.html.erb
+++ b/mlite_rails_app/app/views/devise/shared/_links.html.erb
@@ -1,15 +1,4 @@
  <div class="sm:mx-auto sm:w-full sm:max-w-sm space-y-6">
-    <%- if controller_name != 'sessions' %>
-      <div>
-        <%= link_to "Log in", new_session_path(resource_name), class: "block w-full text-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
-      </div>
-    <%- end %>
-
-    <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-      <div>
-        <%= link_to "Sign up", new_registration_path(resource_name), class: "block w-full text-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
-      </div>
-    <%- end %>
 
     <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
       <div>

--- a/mlite_rails_app/app/views/home/index.html.erb
+++ b/mlite_rails_app/app/views/home/index.html.erb
@@ -1,3 +1,6 @@
-<h1>Hi!</h1>
-<p>This is the homepage for MLite</p>
-<p>Find me in app/views/home/index.html.erb</p>
+<div class="flex flex-col items-center justify-around gap-7">
+  <h1 class="text-5xl">Welcome to MLite</h1>
+
+  <p>If you haven't been here before please select datasets to get started</p>
+</div>
+

--- a/mlite_rails_app/app/views/home/index.html.erb
+++ b/mlite_rails_app/app/views/home/index.html.erb
@@ -1,6 +1,5 @@
 <div class="flex flex-col items-center justify-around gap-7">
-  <h1 class="text-5xl">Welcome to MLite</h1>
-
-  <p>If you haven't been here before please select datasets to get started</p>
+  <div class="w-60 h-60 bg-primary"></div> <!-- Placeholder logo -->
+  <h1 class="text-4xl font-extrabold text-gray-800">Welcome to MLite</h1>
+  <p class="text-md text-gray-600">Sign in or Sign up at the top right to get started.</p>
 </div>
-

--- a/mlite_rails_app/app/views/layouts/_navbar.html.erb
+++ b/mlite_rails_app/app/views/layouts/_navbar.html.erb
@@ -1,39 +1,10 @@
 <% if user_signed_in? %>
   <div class="navbar bg-primary text-primary-content">
     <div class="navbar-start">
-      <div class="dropdown">
-        <div tabindex="0" role="button" class="btn btn-ghost lg:hidden">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="h-5 w-5"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor">
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M4 6h16M4 12h8m-8 6h16" />
-          </svg>
-        </div>
-        <ul
-          tabindex="0"
-          class="menu menu-sm dropdown-content bg-base-100 rounded-box z-[1] mt-3 w-52 p-2 shadow">
-          <li><a>Item 1</a></li>
-          <li>
-            <a>Parent</a>
-            <ul class="p-2">
-              <li><a>Submenu 1</a></li>
-              <li><a>Submenu 2</a></li>
-            </ul>
-          </li>
-          <li><a>Item 3</a></li>
-        </ul>
-      </div>
       <%= link_to 'MLite', root_path, class: "btn btn-ghost text-xl" %>
     </div>
-    <div class="navbar-center hidden lg:flex">
-      <ul class="menu menu-horizontal px-1">
+    <div class="navbar-center flex lg:flex">
+      <ul class="menu menu-horizontal px-1 space-x-2">
         <li><%= link_to 'Datasets', datasets_path %></li>
         <li><%= link_to 'Models', models_path %></li>
         <li><%= link_to 'Deployments', deployments_path %></li>
@@ -48,39 +19,10 @@
 <% else %>
   <div class="navbar bg-primary text-primary-content">
     <div class="navbar-start">
-      <div class="dropdown">
-        <div tabindex="0" role="button" class="btn btn-ghost lg:hidden">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="h-5 w-5"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor">
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M4 6h16M4 12h8m-8 6h16" />
-          </svg>
-        </div>
-        <ul
-          tabindex="0"
-          class="menu menu-sm dropdown-content bg-base-100 rounded-box z-[1] mt-3 w-52 p-2 shadow">
-          <li><a>Item 1</a></li>
-          <li>
-            <a>Parent</a>
-            <ul class="p-2">
-              <li><a>Submenu 1</a></li>
-              <li><a>Submenu 2</a></li>
-            </ul>
-          </li>
-          <li><a>Item 3</a></li>
-        </ul>
-      </div>
       <%= link_to 'MLite', root_path, class: "btn btn-ghost text-xl" %>
     </div>
-    <div class="navbar-center hidden lg:flex">
-      <ul class="menu menu-horizontal px-1">
+    <div class="navbar-center flex lg:flex">
+      <ul class="menu menu-horizontal px-1 space-x-2">
       </ul>
     </div>
     <div class="navbar-end">

--- a/mlite_rails_app/app/views/models/_model.html.erb
+++ b/mlite_rails_app/app/views/models/_model.html.erb
@@ -1,8 +1,9 @@
-<div id="<%= dom_id model %>" class="card bg-base-100 shadow-xl">
+<div id="<%= dom_id model %>" class="card bg-base-100 shadow-xl w-full max-w-full">
   <div class="card-body">
-    <div class="flex flex-row items-center justify-between w-full">
-      <h2 class="card-title text-primary"><%= model.name %></h2>
-      <div class="w-15 flex flex-col items-end gap-2">
+    <div class="flex flex-wrap items-center justify-between w-full">
+      <!-- Model name with overflow handling -->
+      <h2 class="card-title text-primary truncate w-full sm:w-auto" style="max-width: calc(100% - 150px);"><%= model.name %></h2>
+      <div class="w-full sm:w-15 flex flex-col items-end gap-2">
         <span class="<%= case model.status
                          when 'trained' then 'bg-success text-success-content'
                          when 'in-progress' then 'bg-warning text-warning-content'
@@ -16,19 +17,22 @@
       </div>
     </div>
 
-    <p><strong>Description:</strong> <%= model.description %></p>
+    <!-- Updated Description Section to handle long words -->
+    <p><strong>Description:</strong> <span class="break-words"><%= model.description %></span></p>
 
-    <div class="flex flex-row items-start gap-10">
-      <div class="flex flex-col justify-start">
+    <div class="flex flex-wrap gap-10 w-full">
+      <!-- Left Section -->
+      <div class="flex flex-col justify-start w-full sm:w-auto">
         <p><strong>Features:</strong> <%= model.features.join(", ") %></p>
         <p><strong>Labels:</strong> <%= model.labels.join(", ") %></p>
         <p><strong>Size:</strong> <%= human_readable_size(model.size) %></p>
       </div>
-      <div class="flex flex-col justify-start">
+
+      <!-- Right Section (Models and Hyperparams) -->
+      <div class="flex flex-col justify-start w-full sm:w-auto ml-auto">
         <p><strong>Model type:</strong> <%= model.model_type %></p>
         <p><strong>Hyperparams:</strong> <%= model.hyperparams.map { |key, value| "#{key}=#{value}" }.join(", ") %></p>
       </div>
-
     </div>
 
     <div class="card-actions justify-end">
@@ -46,15 +50,15 @@
       <div class="px-3"></div>
 
       <% if model.file.attached? %>
-          <%= link_to rails_blob_path(model.file, disposition: "attachment"), class: "btn text-primary flex items-center justify-center space-x-2" do %>
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
-            </svg>
-          <% end %>
+        <%= link_to rails_blob_path(model.file, disposition: "attachment"), class: "btn text-primary flex items-center justify-center space-x-2" do %>
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
+          </svg>
+        <% end %>
       <% end %>
       <%= link_to new_deployment_path(deployment: {model_id: model.id}), class: "btn btn-primary" do %>
         Deploy
-    <% end %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/mlite_rails_app/app/views/models/_model.html.erb
+++ b/mlite_rails_app/app/views/models/_model.html.erb
@@ -1,9 +1,8 @@
-<div id="<%= dom_id model %>" class="card bg-base-100 shadow-xl w-full max-w-full">
+<div id="<%= dom_id model %>" class="card bg-base-100 shadow-xl" style="min-width: 700px; max-width: 700px">
   <div class="card-body">
-    <div class="flex flex-wrap items-center justify-between w-full">
-      <!-- Model name with overflow handling -->
-      <h2 class="card-title text-primary truncate w-full sm:w-auto" style="max-width: calc(100% - 150px);"><%= model.name %></h2>
-      <div class="w-full sm:w-15 flex flex-col items-end gap-2">
+    <div class="flex flex-row items-center justify-between w-full">
+      <h2 class="card-title text-primary"><%= model.name %></h2>
+      <div class="w-15 flex flex-col items-end gap-2">
         <span class="<%= case model.status
                          when 'trained' then 'bg-success text-success-content'
                          when 'in-progress' then 'bg-warning text-warning-content'
@@ -17,25 +16,26 @@
       </div>
     </div>
 
-    <!-- Updated Description Section to handle long words -->
-    <p><strong>Description:</strong> <span class="break-words"><%= model.description %></span></p>
+    <hr class="text-primary my-2">
 
-    <div class="flex flex-wrap gap-10 w-full">
-      <!-- Left Section -->
-      <div class="flex flex-col justify-start w-full sm:w-auto">
+    <% if model.description.present? %>
+      <p><strong>Description:</strong> <%= model.description %></p>
+    <% end %>
+
+    <div class="flex flex-row items-start gap-10">
+      <div class="flex flex-col justify-start">
         <p><strong>Features:</strong> <%= model.features.join(", ") %></p>
         <p><strong>Labels:</strong> <%= model.labels.join(", ") %></p>
         <p><strong>Size:</strong> <%= human_readable_size(model.size) %></p>
       </div>
-
-      <!-- Right Section (Models and Hyperparams) -->
-      <div class="flex flex-col justify-start w-full sm:w-auto ml-auto">
+      <div class="flex flex-col justify-start">
         <p><strong>Model type:</strong> <%= model.model_type %></p>
         <p><strong>Hyperparams:</strong> <%= model.hyperparams.map { |key, value| "#{key}=#{value}" }.join(", ") %></p>
       </div>
+
     </div>
 
-    <div class="card-actions justify-end">
+    <div class="card-actions justify-center">
       <%= link_to edit_model_path(model), class: "btn text-secondary flex items-center justify-center space-x-2" do %>
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
           <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
@@ -50,15 +50,15 @@
       <div class="px-3"></div>
 
       <% if model.file.attached? %>
-        <%= link_to rails_blob_path(model.file, disposition: "attachment"), class: "btn text-primary flex items-center justify-center space-x-2" do %>
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
-          </svg>
-        <% end %>
+          <%= link_to rails_blob_path(model.file, disposition: "attachment"), class: "btn text-primary flex items-center justify-center space-x-2" do %>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
+            </svg>
+          <% end %>
       <% end %>
       <%= link_to new_deployment_path(deployment: {model_id: model.id}), class: "btn btn-primary" do %>
         Deploy
-      <% end %>
+    <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Features

- Changed the width of the cards in the datasets, models, and deployments index pages.
- Made the names for any dataset, model, or deployment be cut if they try to extend past the page boundaries.
- Made the descriptions for any dataset, model, or deployment move down a line if they try to extend past the page boundaries.
- Added styling to the forgot password page.
- Added styling to the resend confirmation instructions page.
- Fixed the navbar for smaller windows.
- Added styling to the home page.

Testing

- Go to the datasets index page
- Compress the page size
- Go to the models index page
- Compress the page size
- Go to the deployments index page
- Compress the page size
- Go to the forgot password page
- Go to the resend confirmation instructions page
- Go to the home page