### PR TITLE
fix(models#create): Validate recommended model selection

### DIFF
--- a/mlite_rails_app/app/controllers/models_controller.rb
+++ b/mlite_rails_app/app/controllers/models_controller.rb
@@ -39,7 +39,7 @@ class ModelsController < ApplicationController
     if selected_model_index.nil? || params[:recommended_models][selected_model_index].nil?
       @model = Model.new(model_params) # Initialize model with any provided data
       assign_variables_for_new
-      flash.now[:alert] = "You must select a recommended model before proceeding."
+      flash.now[:alert] = "You must select a recommended model from the list before proceeding."
       render :new, status: :unprocessable_entity and return
     end
     model_type = params[:recommended_models][selected_model_index][:model_type]

--- a/mlite_rails_app/app/controllers/models_controller.rb
+++ b/mlite_rails_app/app/controllers/models_controller.rb
@@ -35,6 +35,13 @@ class ModelsController < ApplicationController
   # POST /models or /models.json
   def create
     selected_model_index = params[:model][:selected_model]
+
+    if selected_model_index.nil? || params[:recommended_models][selected_model_index].nil?
+      @model = Model.new(model_params) # Initialize model with any provided data
+      assign_variables_for_new
+      flash.now[:alert] = "You must select a recommended model before proceeding."
+      render :new, status: :unprocessable_entity and return
+    end
     model_type = params[:recommended_models][selected_model_index][:model_type]
     hyperparams = JSON.parse(params[:recommended_models][selected_model_index][:hyperparams])
     @columns = ['iris_width', 'iris_length', 'iris_species'] # hardcoded for now

--- a/mlite_rails_app/app/helpers/application_helper.rb
+++ b/mlite_rails_app/app/helpers/application_helper.rb
@@ -11,4 +11,13 @@ module ApplicationHelper
 
     "#{size.round(2)} #{unit}"
   end
+
+  def class_for_flash(type)
+    case type
+    when 'alert'
+      'alert-warning'
+    else
+      'alert-success'
+    end
+  end
 end

--- a/mlite_rails_app/app/views/layouts/_flash.html.erb
+++ b/mlite_rails_app/app/views/layouts/_flash.html.erb
@@ -1,6 +1,6 @@
 <div class="absolute top-20 right-5 mb-3 w-1/5">
   <% flash.each do |type, message| %>
-    <div data-controller="flash" class="alert alert-success" role="alert">
+    <div data-controller="flash" class="alert <%= class_for_flash(type) %>" role="alert">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         class="h-6 w-6 shrink-0 stroke-current"


### PR DESCRIPTION
### Description
This pull request introduces a fix to validate the selection of a recommended model during the creation of a new model. If no recommendation is selected, an appropriate error message is displayed, and the form is re-rendered to allow the user to correct the input.

### Changes Made

**Validation for selected_model_index:**
- Added a check in the create action of the ModelsController to ensure selected_model_index is not nil and exists in params[:recommended_models].

**If no model is selected:**
- An error message is displayed: "You must select a recommended model before proceeding."

